### PR TITLE
[ISSUE-13] Edited staffs/index style

### DIFF
--- a/app/views/staffs/index.html.erb
+++ b/app/views/staffs/index.html.erb
@@ -36,7 +36,7 @@
             <td><%= staff.email %></td>
             <td><%= staff.department.name %></td>
             <td><%= staff.status %></td>
-            <td>₱<%= number_with_delimiter(number_with_precision(staff.monthly_salary, precision: 2)) %></td>
+            <td><%= number_to_currency(staff.monthly_salary, precision: 2, unit: '₱', delimiter: ',') %></td>
             <td class="d-flex gap-2">
               <%= link_to "Show", staff, class: "btn btn-sm btn-outline-primary" %>
               <%= link_to "Edit", edit_staff_path(staff), class: "btn btn-sm btn-outline-secondary" %>


### PR DESCRIPTION
### Staff Index
<img width="1905" height="952" alt="image" src="https://github.com/user-attachments/assets/54fbe92c-30d7-45f1-b268-dffe4f78e086" />

### Monthly Salary Column Edit
I also added `number_with_precision(staff.monthly_salary, precision: 2)` inside the `number_with_delimiter` to have a fixed **Hundrendths**
<img width="164" height="189" alt="image" src="https://github.com/user-attachments/assets/1eafbee1-3e10-4158-a190-5192f8d2455a" />
